### PR TITLE
Heroicons v2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     ],
     "require": {
         "php": "^8.0|^8.1",
-        "rapidez/core": "~0.57"
+        "rapidez/core": "~0.57",
+        "blade-ui-kit/blade-heroicons": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/resources/views/components/productbundles.blade.php
+++ b/resources/views/components/productbundles.blade.php
@@ -74,7 +74,7 @@
                             </div>
                             <x-rapidez::button type="submit" class="flex items-center mx-auto mt-3">
                                 <x-heroicon-o-shopping-cart class="h-5 w-5 mr-2" v-if="!adding && !added" />
-                                <x-heroicon-o-refresh class="h-5 w-5 mr-2 animate-spin" v-if="adding" />
+                                <x-heroicon-o-arrow-path class="h-5 w-5 mr-2 animate-spin" v-if="adding" />
                                 <x-heroicon-o-check class="h-5 w-5 mr-2" v-if="added" />
                                 <span v-if="!adding && !added">@lang('Add bundle')</span>
                                 <span v-if="adding">@lang('Adding')...</span>


### PR DESCRIPTION
In https://github.com/rapidez/core/pull/304, I updated Heroicons to version 2. In the update, some icons have changed, so this should also be updated in the rapidez/amasty-automatic-related-products package.